### PR TITLE
CSS help

### DIFF
--- a/12_r-startup.Rmd
+++ b/12_r-startup.Rmd
@@ -1,10 +1,3 @@
----
-output:
-  bookdown::html_book:
-    includes:
-      in_header: style.css
----
-
 # R Startup
 
 R has been designed to be used from shared computing resources such as linux

--- a/_output.yml
+++ b/_output.yml
@@ -11,7 +11,7 @@ bookdown::gitbook:
     toc:
       collapse: section
       before: |
-        <li><a href="./">What They Forgot to Teach You About R</a></li>
+        <li><a href="./">https://rstats.wtf/</a></li>
       after: |
         <li><a href="https://github.com/rstudio/bookdown" target="blank">Published with bookdown</a></li>
     edit: https://github.com/rstats-wtf/what-they-forgot/edit/master/%s

--- a/index.Rmd
+++ b/index.Rmd
@@ -1,6 +1,8 @@
 --- 
 title: "What They Forgot to Teach You About R"
-author: "Jennifer Bryan, Jim Hester"
+author:
+  - Jennifer Bryan
+  - Jim Hester
 site: bookdown::bookdown_site
 output: bookdown::gitbook
 documentclass: book

--- a/style.css
+++ b/style.css
@@ -35,3 +35,22 @@ pre code {
 .rmdwarning {
   background-image: url("images/warning.png");
 }
+
+/* These two rules make the horizontal line go straight across in top navbar */
+
+.summary > li:first-child {
+	height: 50px;
+	padding-top: 10px;
+	border-bottom: 1px solid rgba(0,0,0,.07);
+}
+
+.book .book-summary ul.summary li.divider {
+	height: 0px;
+}
+
+/* Hide first level-one markdown header from only the chapter named
+what-they-forgot-to-teach-you-about-r */
+
+#what-they-forgot-to-teach-you-about-r > h1:nth-child(1){
+  visibility: hidden;
+}


### PR DESCRIPTION
Hi @jennybc,

I made some very basic style adjustments to reduce repetition in the TOC (made the link the top of the TOC) and on the index page (I hid the first level-one header) *[edited to add: I also added some CSS rules to make the top line going from the TOC through the header match up. Small tweak but I think it helps visually]*.

I also separated out the authors in the `index.Rmd` YAML to improve meta tagging and search-ability by author name.

Here is a screenshot of the 3 main changes:
<img width="1312" alt="Screen Shot 2019-10-23 at 10 14 31 AM" src="https://user-images.githubusercontent.com/12160301/67418145-1bf1e480-f57f-11e9-88c3-519078a8418f.png">




Along the way I also got this error when building the book:

```
Warning message:
In split_chapters(output, gitbook_page, number_sections, split_by,  :
  You have 17 Rmd input file(s) but only 16 first-level heading(s). Did you forget first-level headings in certain Rmd files?
```

This was due to an errant YAML appearing in Chapter 12, so I removed that to resolve the error.

I'm happy to walk back any of these changes, but would also be ecstatic to go *just a bit further* to get rid of the default bookdown fonts but didn't want to get too carried away :wink: Just say the word if you are ready for that!