### PR TITLE
update link

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -59,7 +59,7 @@ both overlap and diverge in content.
 
 Upcoming and past offerings:
 
-  * [posit::conf 2023](https://posit.co/conference/), Chicago, IL
+  * [posit::conf 2023](https://github.com/posit-conf-2023/wtf), Chicago, IL
   * [rstudio::conf 2022](https://rstats-wtf.github.io/wtf-2022-rsc/), Oxon Hill, MD
   * [rstudio::conf 2020](https://rstats-wtf.github.io/wtf-2020-rsc/), San Francisco, CA
   * [rstudio::conf 2019](https://rstats-wtf.github.io/wtf-2019-rsc/), Austin, TX


### PR DESCRIPTION
change posit conf workshop link to point to workshop readme rather than conference site